### PR TITLE
refactor(connection-string): 修改协议名称为 gaussdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 /.eslintcache
 .vscode/
 manually-test-on-heroku.js
+**/.*nyc_output/

--- a/docs/pages/apis/client.mdx
+++ b/docs/pages/apis/client.mdx
@@ -15,7 +15,7 @@ type Config = {
   host?: string, // default process.env.PGHOST
   port?: number, // default process.env.PGPORT
   database?: string, // default process.env.PGDATABASE || user
-  connectionString?: string, // e.g. postgres://user:password@host:5432/database
+  connectionString?: string, // e.g. gaussdb://user:password@host:5432/database
   ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
   types?: any, // custom type parsers
   statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout

--- a/docs/pages/features/ssl.mdx
+++ b/docs/pages/features/ssl.mdx
@@ -42,7 +42,7 @@ If you plan to use a combination of a database connection string from the enviro
 
 ```js
 const config = {
-  connectionString: 'postgres://user:password@host:port/db?sslmode=require',
+  connectionString: 'gaussdb://user:password@host:port/db?sslmode=require',
   // Beware! The ssl object is overwritten when parsing the connectionString
   ssl: {
     rejectUnauthorized: false,

--- a/packages/gaussdb-connection-string/.nyc_output/processinfo/index.json
+++ b/packages/gaussdb-connection-string/.nyc_output/processinfo/index.json
@@ -1,1 +1,0 @@
-{"processes":{"4c70412b-c816-446c-afc4-b9c2db64880d":{"parent":null,"children":[]}},"files":{"/home/happy/gaussdb-node/packages/pg-connection-string/index.js":["4c70412b-c816-446c-afc4-b9c2db64880d"]},"externalIds":{}}

--- a/packages/gaussdb-connection-string/README.md
+++ b/packages/gaussdb-connection-string/README.md
@@ -14,7 +14,7 @@ MIT License
 ```js
 const parse = require('pg-connection-string').parse;
 
-const config = parse('postgres://someuser:somepassword@somehost:381/somedatabase')
+const config = parse('gaussdb://someuser:somepassword@somehost:381/somedatabase')
 ```
 
 The resulting config contains a subset of the following properties:
@@ -40,7 +40,7 @@ The pg-connection-string `ConnectionOptions` interface is not compatible with th
 import { ClientConfig } from 'pg';
 import { parseIntoClientConfig } from 'pg-connection-string';
 
-const config: ClientConfig = parseIntoClientConfig('postgres://someuser:somepassword@somehost:381/somedatabase')
+const config: ClientConfig = parseIntoClientConfig('gaussdb://someuser:somepassword@somehost:381/somedatabase')
 ```
 
 You can also use `toClientConfig` to convert an existing `ConnectionOptions` interface into a `ClientConfig` interface:
@@ -49,7 +49,7 @@ You can also use `toClientConfig` to convert an existing `ConnectionOptions` int
 import { ClientConfig } from 'pg';
 import { parse, toClientConfig } from 'pg-connection-string';
 
-const config = parse('postgres://someuser:somepassword@somehost:381/somedatabase')
+const config = parse('gaussdb://someuser:somepassword@somehost:381/somedatabase')
 const clientConfig: ClientConfig = toClientConfig(config)
 ```
 
@@ -58,7 +58,7 @@ const clientConfig: ClientConfig = toClientConfig(config)
 The short summary of acceptable URLs is:
 
  * `socket:<path>?<query>` - UNIX domain socket
- * `postgres://<user>:<password>@<host>:<port>/<database>?<query>` - TCP connection
+ * `gaussdb://<user>:<password>@<host>:<port>/<database>?<query>` - TCP connection
 
 But see below for more details.
 

--- a/packages/gaussdb-connection-string/index.js
+++ b/packages/gaussdb-connection-string/index.js
@@ -23,10 +23,10 @@ function parse(str, options = {}) {
   }
 
   try {
-    result = new URL(str, 'postgres://base')
+    result = new URL(str, 'gaussdb://base')
   } catch (e) {
     // The URL is invalid so try again with a dummy host
-    result = new URL(str.replace('@/', '@___DUMMY___/'), 'postgres://base')
+    result = new URL(str.replace('@/', '@___DUMMY___/'), 'gaussdb://base')
     dummyHost = true
   }
 

--- a/packages/gaussdb-connection-string/test/clientConfig.ts
+++ b/packages/gaussdb-connection-string/test/clientConfig.ts
@@ -6,7 +6,7 @@ import { parse, toClientConfig, parseIntoClientConfig } from '../'
 
 describe('toClientConfig', function () {
   it('converts connection info', function () {
-    const config = parse('postgres://brian:pw@boom:381/lala')
+    const config = parse('gaussdb://brian:pw@boom:381/lala')
     const clientConfig = toClientConfig(config)
 
     clientConfig.user?.should.equal('brian')
@@ -18,7 +18,7 @@ describe('toClientConfig', function () {
 
   it('converts query params', function () {
     const config = parse(
-      'postgres:///?application_name=TheApp&fallback_application_name=TheAppFallback&client_encoding=utf8&options=-c geqo=off'
+      'gaussdb:///?application_name=TheApp&fallback_application_name=TheAppFallback&client_encoding=utf8&options=-c geqo=off'
     )
     const clientConfig = toClientConfig(config)
 
@@ -29,21 +29,21 @@ describe('toClientConfig', function () {
   })
 
   it('converts SSL boolean', function () {
-    const config = parse('pg:///?ssl=true')
+    const config = parse('gaussdb:///?ssl=true')
     const clientConfig = toClientConfig(config)
 
     clientConfig.ssl?.should.equal(true)
   })
 
   it('converts sslmode=disable', function () {
-    const config = parse('pg:///?sslmode=disable')
+    const config = parse('gaussdb:///?sslmode=disable')
     const clientConfig = toClientConfig(config)
 
     clientConfig.ssl?.should.equal(false)
   })
 
   it('converts sslmode=noverify', function () {
-    const config = parse('pg:///?sslmode=no-verify')
+    const config = parse('gaussdb:///?sslmode=no-verify')
     const clientConfig = toClientConfig(config)
 
     clientConfig.ssl?.should.deep.equal({
@@ -52,14 +52,14 @@ describe('toClientConfig', function () {
   })
 
   it('converts other sslmode options', function () {
-    const config = parse('pg:///?sslmode=verify-ca')
+    const config = parse('gaussdb:///?sslmode=verify-ca')
     const clientConfig = toClientConfig(config)
 
     clientConfig.ssl?.should.deep.equal({})
   })
 
   it('converts other sslmode options', function () {
-    const config = parse('pg:///?sslmode=verify-ca')
+    const config = parse('gaussdb:///?sslmode=verify-ca')
     const clientConfig = toClientConfig(config)
 
     clientConfig.ssl?.should.deep.equal({})
@@ -67,7 +67,7 @@ describe('toClientConfig', function () {
 
   it('converts ssl cert options', function () {
     const connectionString =
-      'pg:///?sslcert=' +
+      'gaussdb:///?sslcert=' +
       __dirname +
       '/example.cert&sslkey=' +
       __dirname +
@@ -93,13 +93,13 @@ describe('toClientConfig', function () {
   })
 
   it('handles invalid port', function () {
-    const config = parse('postgres://@boom:381/lala')
+    const config = parse('gaussdb://@boom:381/lala')
     config.port = 'bogus'
     expect(() => toClientConfig(config)).to.throw()
   })
 
   it('handles invalid sslconfig values', function () {
-    const config = parse('postgres://@boom/lala')
+    const config = parse('gaussdb://@boom/lala')
     config.ssl = {}
     config.ssl.cert = null
     config.ssl.key = undefined
@@ -114,7 +114,7 @@ describe('toClientConfig', function () {
 
 describe('parseIntoClientConfig', function () {
   it('converts url', function () {
-    const clientConfig = parseIntoClientConfig('postgres://brian:pw@boom:381/lala')
+    const clientConfig = parseIntoClientConfig('gaussdb://brian:pw@boom:381/lala')
 
     clientConfig.user?.should.equal('brian')
     clientConfig.password?.should.equal('pw')

--- a/packages/gaussdb-connection-string/test/parse.ts
+++ b/packages/gaussdb-connection-string/test/parse.ts
@@ -6,7 +6,7 @@ import { parse } from '../'
 
 describe('parse', function () {
   it('using connection string in client constructor', function () {
-    const subject = parse('postgres://brian:pw@boom:381/lala')
+    const subject = parse('gaussdb://brian:pw@boom:381/lala')
     subject.user?.should.equal('brian')
     subject.password?.should.equal('pw')
     subject.host?.should.equal('boom')
@@ -15,12 +15,12 @@ describe('parse', function () {
   })
 
   it('escape spaces if present', function () {
-    const subject = parse('postgres://localhost/post gres')
+    const subject = parse('gaussdb://localhost/post gres')
     subject.database?.should.equal('post gres')
   })
 
   it('do not double escape spaces', function () {
-    const subject = parse('postgres://localhost/post%20gres')
+    const subject = parse('gaussdb://localhost/post%20gres')
     subject.database?.should.equal('post gres')
   })
 
@@ -66,7 +66,7 @@ describe('parse', function () {
       database: 'postgres',
     }
     const connectionString =
-      'postgres://' +
+      'gaussdb://' +
       sourceConfig.user +
       ':' +
       sourceConfig.password +
@@ -89,7 +89,7 @@ describe('parse', function () {
       database: 'postgres',
     }
     const connectionString =
-      'postgres://' +
+      'gaussdb://' +
       sourceConfig.user +
       ':' +
       sourceConfig.password +
@@ -104,7 +104,7 @@ describe('parse', function () {
   })
 
   it('username or password contains weird characters', function () {
-    const strang = 'pg://my f%irst name:is&%awesome!@localhost:9000'
+    const strang = 'gaussdb://my f%irst name:is&%awesome!@localhost:9000'
     const subject = parse(strang)
     subject.user?.should.equal('my f%irst name')
     subject.password?.should.equal('is&%awesome!')
@@ -112,7 +112,7 @@ describe('parse', function () {
   })
 
   it('url is properly encoded', function () {
-    const encoded = 'pg://bi%25na%25%25ry%20:s%40f%23@localhost/%20u%2520rl'
+    const encoded = 'gaussdb://bi%25na%25%25ry%20:s%40f%23@localhost/%20u%2520rl'
     const subject = parse(encoded)
     subject.user?.should.equal('bi%na%%ry ')
     subject.password?.should.equal('s@f#')
@@ -127,18 +127,18 @@ describe('parse', function () {
   })
 
   it('no pathname returns null database', function () {
-    const subject = parse('pg://myhost')
+    const subject = parse('gaussdb://myhost')
     ;(subject.database === null).should.equal(true)
   })
 
   it('pathname of "/" returns null database', function () {
-    const subject = parse('pg://myhost/')
+    const subject = parse('gaussdb://myhost/')
     subject.host?.should.equal('myhost')
     ;(subject.database === null).should.equal(true)
   })
 
   it('configuration parameter host', function () {
-    const subject = parse('pg://user:pass@/dbname?host=/unix/socket')
+    const subject = parse('gaussdb://user:pass@/dbname?host=/unix/socket')
     subject.user?.should.equal('user')
     subject.password?.should.equal('pass')
     subject.host?.should.equal('/unix/socket')
@@ -146,13 +146,13 @@ describe('parse', function () {
   })
 
   it('configuration parameter host overrides url host', function () {
-    const subject = parse('pg://user:pass@localhost/dbname?host=/unix/socket')
+    const subject = parse('gaussdb://user:pass@localhost/dbname?host=/unix/socket')
     subject.database?.should.equal('dbname')
     subject.host?.should.equal('/unix/socket')
   })
 
   it('url with encoded socket', function () {
-    const subject = parse('pg://user:pass@%2Funix%2Fsocket/dbname')
+    const subject = parse('gaussdb://user:pass@%2Funix%2Fsocket/dbname')
     subject.user?.should.equal('user')
     subject.password?.should.equal('pass')
     subject.host?.should.equal('/unix/socket')
@@ -160,7 +160,7 @@ describe('parse', function () {
   })
 
   it('url with real host and an encoded db name', function () {
-    const subject = parse('pg://user:pass@localhost/%2Fdbname')
+    const subject = parse('gaussdb://user:pass@localhost/%2Fdbname')
     subject.user?.should.equal('user')
     subject.password?.should.equal('pass')
     subject.host?.should.equal('localhost')
@@ -168,7 +168,7 @@ describe('parse', function () {
   })
 
   it('configuration parameter host treats encoded host as part of the db name', function () {
-    const subject = parse('pg://user:pass@%2Funix%2Fsocket/dbname?host=localhost')
+    const subject = parse('gaussdb://user:pass@%2Funix%2Fsocket/dbname?host=localhost')
     subject.user?.should.equal('user')
     subject.password?.should.equal('pass')
     subject.host?.should.equal('localhost')
@@ -176,48 +176,48 @@ describe('parse', function () {
   })
 
   it('configuration parameter application_name', function () {
-    const connectionString = 'pg:///?application_name=TheApp'
+    const connectionString = 'gaussdb:///?application_name=TheApp'
     const subject = parse(connectionString)
     subject.application_name?.should.equal('TheApp')
   })
 
   it('configuration parameter fallback_application_name', function () {
-    const connectionString = 'pg:///?fallback_application_name=TheAppFallback'
+    const connectionString = 'gaussdb:///?fallback_application_name=TheAppFallback'
     const subject = parse(connectionString)
     subject.fallback_application_name?.should.equal('TheAppFallback')
   })
 
   it('configuration parameter options', function () {
-    const connectionString = 'pg:///?options=-c geqo=off'
+    const connectionString = 'gaussdb:///?options=-c geqo=off'
     const subject = parse(connectionString)
     subject.options?.should.equal('-c geqo=off')
   })
 
   it('configuration parameter ssl=true', function () {
-    const connectionString = 'pg:///?ssl=true'
+    const connectionString = 'gaussdb:///?ssl=true'
     const subject = parse(connectionString)
     subject.ssl?.should.equal(true)
   })
 
   it('configuration parameter ssl=1', function () {
-    const connectionString = 'pg:///?ssl=1'
+    const connectionString = 'gaussdb:///?ssl=1'
     const subject = parse(connectionString)
     subject.ssl?.should.equal(true)
   })
 
   it('configuration parameter ssl=0', function () {
-    const connectionString = 'pg:///?ssl=0'
+    const connectionString = 'gaussdb:///?ssl=0'
     const subject = parse(connectionString)
     subject.ssl?.should.equal(false)
   })
 
   it('set ssl', function () {
-    const subject = parse('pg://myhost/db?ssl=1')
+    const subject = parse('gaussdb://myhost/db?ssl=1')
     subject.ssl?.should.equal(true)
   })
 
   it('configuration parameter sslcert=/path/to/cert', function () {
-    const connectionString = 'pg:///?sslcert=' + __dirname + '/example.cert'
+    const connectionString = 'gaussdb:///?sslcert=' + __dirname + '/example.cert'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       cert: 'example cert\n',
@@ -225,7 +225,7 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslkey=/path/to/key', function () {
-    const connectionString = 'pg:///?sslkey=' + __dirname + '/example.key'
+    const connectionString = 'gaussdb:///?sslkey=' + __dirname + '/example.key'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       key: 'example key\n',
@@ -233,7 +233,7 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslrootcert=/path/to/ca', function () {
-    const connectionString = 'pg:///?sslrootcert=' + __dirname + '/example.ca'
+    const connectionString = 'gaussdb:///?sslrootcert=' + __dirname + '/example.ca'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       ca: 'example ca\n',
@@ -241,7 +241,7 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=no-verify', function () {
-    const connectionString = 'pg:///?sslmode=no-verify'
+    const connectionString = 'gaussdb:///?sslmode=no-verify'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       rejectUnauthorized: false,
@@ -249,37 +249,37 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=disable', function () {
-    const connectionString = 'pg:///?sslmode=disable'
+    const connectionString = 'gaussdb:///?sslmode=disable'
     const subject = parse(connectionString)
     subject.ssl?.should.eql(false)
   })
 
   it('configuration parameter sslmode=prefer', function () {
-    const connectionString = 'pg:///?sslmode=prefer'
+    const connectionString = 'gaussdb:///?sslmode=prefer'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({})
   })
 
   it('configuration parameter sslmode=require', function () {
-    const connectionString = 'pg:///?sslmode=require'
+    const connectionString = 'gaussdb:///?sslmode=require'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({})
   })
 
   it('configuration parameter sslmode=verify-ca', function () {
-    const connectionString = 'pg:///?sslmode=verify-ca'
+    const connectionString = 'gaussdb:///?sslmode=verify-ca'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({})
   })
 
   it('configuration parameter sslmode=verify-full', function () {
-    const connectionString = 'pg:///?sslmode=verify-full'
+    const connectionString = 'gaussdb:///?sslmode=verify-full'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({})
   })
 
   it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca', function () {
-    const connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
+    const connectionString = 'gaussdb:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       ca: 'example ca\n',
@@ -287,13 +287,13 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=disable with uselibpqcompat query param', function () {
-    const connectionString = 'pg:///?sslmode=disable&uselibpqcompat=true'
+    const connectionString = 'gaussdb:///?sslmode=disable&uselibpqcompat=true'
     const subject = parse(connectionString)
     subject.ssl?.should.eql(false)
   })
 
   it('configuration parameter sslmode=prefer with uselibpqcompat query param', function () {
-    const connectionString = 'pg:///?sslmode=prefer&uselibpqcompat=true'
+    const connectionString = 'gaussdb:///?sslmode=prefer&uselibpqcompat=true'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       rejectUnauthorized: false,
@@ -301,7 +301,7 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=require with uselibpqcompat query param', function () {
-    const connectionString = 'pg:///?sslmode=require&uselibpqcompat=true'
+    const connectionString = 'gaussdb:///?sslmode=require&uselibpqcompat=true'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({
       rejectUnauthorized: false,
@@ -309,14 +309,15 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=verify-ca with uselibpqcompat query param', function () {
-    const connectionString = 'pg:///?sslmode=verify-ca&uselibpqcompat=true'
+    const connectionString = 'gaussdb:///?sslmode=verify-ca&uselibpqcompat=true'
     expect(function () {
       parse(connectionString)
     }).to.throw()
   })
 
   it('configuration parameter sslmode=verify-ca and sslrootcert with uselibpqcompat query param', function () {
-    const connectionString = 'pg:///?sslmode=verify-ca&uselibpqcompat=true&sslrootcert=' + __dirname + '/example.ca'
+    const connectionString =
+      'gaussdb:///?sslmode=verify-ca&uselibpqcompat=true&sslrootcert=' + __dirname + '/example.ca'
     const subject = parse(connectionString)
     subject.ssl?.should.have.property('checkServerIdentity').that.is.a('function')
     // We prove above that the checkServerIdentity function is defined
@@ -327,14 +328,14 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=verify-full with uselibpqcompat query param', function () {
-    const connectionString = 'pg:///?sslmode=verify-full&uselibpqcompat=true'
+    const connectionString = 'gaussdb:///?sslmode=verify-full&uselibpqcompat=true'
     const subject = parse(connectionString)
     subject.ssl?.should.eql({})
   })
 
   it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with uselibpqcompat query param', function () {
     const connectionString =
-      'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require&uselibpqcompat=true'
+      'gaussdb:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require&uselibpqcompat=true'
     const subject = parse(connectionString)
     subject.ssl?.should.have.property('ca', 'example ca\n')
     subject.ssl?.should.have.property('checkServerIdentity').that.is.a('function')
@@ -346,13 +347,13 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=disable with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?sslmode=disable'
+    const connectionString = 'gaussdb:///?sslmode=disable'
     const subject = parse(connectionString, { useLibpqCompat: true })
     subject.ssl?.should.eql(false)
   })
 
   it('configuration parameter sslmode=prefer with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?sslmode=prefer'
+    const connectionString = 'gaussdb:///?sslmode=prefer'
     const subject = parse(connectionString, { useLibpqCompat: true })
     subject.ssl?.should.eql({
       rejectUnauthorized: false,
@@ -360,7 +361,7 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=require with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?sslmode=require'
+    const connectionString = 'gaussdb:///?sslmode=require'
     const subject = parse(connectionString, { useLibpqCompat: true })
     subject.ssl?.should.eql({
       rejectUnauthorized: false,
@@ -368,14 +369,14 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=verify-ca with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?sslmode=verify-ca'
+    const connectionString = 'gaussdb:///?sslmode=verify-ca'
     expect(function () {
       parse(connectionString, { useLibpqCompat: true })
     }).to.throw()
   })
 
   it('configuration parameter sslmode=verify-ca and sslrootcert with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?sslmode=verify-ca&sslrootcert=' + __dirname + '/example.ca'
+    const connectionString = 'gaussdb:///?sslmode=verify-ca&sslrootcert=' + __dirname + '/example.ca'
     const subject = parse(connectionString, { useLibpqCompat: true })
     subject.ssl?.should.have.property('checkServerIdentity').that.is.a('function')
     // We prove above that the checkServerIdentity function is defined
@@ -386,13 +387,13 @@ describe('parse', function () {
   })
 
   it('configuration parameter sslmode=verify-full with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?sslmode=verify-full'
+    const connectionString = 'gaussdb:///?sslmode=verify-full'
     const subject = parse(connectionString, { useLibpqCompat: true })
     subject.ssl?.should.eql({})
   })
 
   it('configuration parameter ssl=true and sslmode=require still work with sslrootcert=/path/to/ca with useLibpqCompat option', function () {
-    const connectionString = 'pg:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
+    const connectionString = 'gaussdb:///?ssl=true&sslrootcert=' + __dirname + '/example.ca&sslmode=require'
     const subject = parse(connectionString, { useLibpqCompat: true })
     subject.ssl?.should.have.property('ca', 'example ca\n')
     subject.ssl?.should.have.property('checkServerIdentity').that.is.a('function')
@@ -404,26 +405,26 @@ describe('parse', function () {
   })
 
   it('does not allow uselibpqcompat query parameter and useLibpqCompat option at the same time', function () {
-    const connectionString = 'pg:///?uselibpqcompat=true'
+    const connectionString = 'gaussdb:///?uselibpqcompat=true'
     expect(function () {
       parse(connectionString, { useLibpqCompat: true })
     }).to.throw()
   })
 
   it('allow other params like max, ...', function () {
-    const subject = parse('pg://myhost/db?max=18&min=4')
+    const subject = parse('gaussdb://myhost/db?max=18&min=4')
     subject.max?.should.equal('18')
     subject.min?.should.equal('4')
   })
 
   it('configuration parameter keepalives', function () {
-    const connectionString = 'pg:///?keepalives=1'
+    const connectionString = 'gaussdb:///?keepalives=1'
     const subject = parse(connectionString)
     subject.keepalives?.should.equal('1')
   })
 
   it('unknown configuration parameter is passed into client', function () {
-    const connectionString = 'pg:///?ThereIsNoSuchPostgresParameter=1234'
+    const connectionString = 'gaussdb:///?ThereIsNoSuchPostgresParameter=1234'
     const subject = parse(connectionString)
     subject.ThereIsNoSuchPostgresParameter?.should.equal('1234')
   })
@@ -436,13 +437,13 @@ describe('parse', function () {
   })
 
   it('return last value of repeated parameter', function () {
-    const connectionString = 'pg:///?keepalives=1&keepalives=0'
+    const connectionString = 'gaussdb:///?keepalives=1&keepalives=0'
     const subject = parse(connectionString)
     subject.keepalives?.should.equal('0')
   })
 
   it('use the port specified in the query parameters', function () {
-    const connectionString = 'postgres:///?host=localhost&port=1234'
+    const connectionString = 'gaussdb:///?host=localhost&port=1234'
     const subject = parse(connectionString)
     subject.port?.should.equal('1234')
   })

--- a/packages/gaussdb-pool/README.md
+++ b/packages/gaussdb-pool/README.md
@@ -69,7 +69,7 @@ const config = {
 const pool = new Pool(config);
 
 /*
-  Transforms, 'postgres://DBuser:secret@DBHost:#####/myDB', into
+  Transforms, 'gaussdb://DBuser:secret@DBHost:#####/myDB', into
   config = {
     user: 'DBuser',
     password: 'secret',

--- a/packages/gaussdb-pool/test/connection-strings.js
+++ b/packages/gaussdb-pool/test/connection-strings.js
@@ -5,7 +5,7 @@ const Pool = require('../')
 
 describe('Connection strings', function () {
   it('pool delegates connectionString property to client', function (done) {
-    const connectionString = 'postgres://foo:bar@baz:1234/xur'
+    const connectionString = 'gaussdb://foo:bar@baz:1234/xur'
 
     const pool = new Pool({
       // use a fake client so we can check we're passed the connectionString

--- a/packages/gaussdb/Makefile
+++ b/packages/gaussdb/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/sh
 
-connectionString=postgres://
+connectionString=gaussdb://
 
 params := $(connectionString)
 
@@ -13,7 +13,7 @@ all:
 	npm install
 
 help:
-	@echo "make test-all [connectionString=postgres://<your connection string>]"
+	@echo "make test-all [connectionString=gaussdb://<your connection string>]"
 
 test: test-unit
 

--- a/packages/gaussdb/test/integration/client/api-tests.js
+++ b/packages/gaussdb/test/integration/client/api-tests.js
@@ -180,7 +180,7 @@ suite.test('executing nested queries', function (done) {
 })
 
 suite.test('raises error if cannot connect', function () {
-  const connectionString = 'pg://sfalsdkf:asdf@localhost/ieieie'
+  const connectionString = 'gaussdb://sfalsdkf:asdf@localhost/ieieie'
   const pool = new pg.Pool({ connectionString: connectionString })
   pool.connect(
     assert.calls(function (err, client, done) {

--- a/packages/gaussdb/test/integration/client/appname-tests.js
+++ b/packages/gaussdb/test/integration/client/appname-tests.js
@@ -76,7 +76,7 @@ suite.test('application_name from connection string', function (done) {
   if (process.argv[2]) {
     conf = new conParams(process.argv[2] + '?application_name=' + appName)
   } else {
-    conf = 'postgres://?application_name=' + appName
+    conf = 'gaussdb://?application_name=' + appName
   }
   getAppName(conf, function (res) {
     assert.strictEqual(res, appName)

--- a/packages/gaussdb/test/unit/client/configuration-tests.js
+++ b/packages/gaussdb/test/unit/client/configuration-tests.js
@@ -63,7 +63,7 @@ test('client settings', function () {
 test('initializing from a config string', function () {
   test('uses connectionString property', function () {
     const client = new Client({
-      connectionString: 'postgres://brian:pass@host1:333/databasename',
+      connectionString: 'gaussdb://brian:pass@host1:333/databasename',
     })
     assert.equal(client.user, 'brian')
     assert.equal(client.password, 'pass')
@@ -73,7 +73,7 @@ test('initializing from a config string', function () {
   })
 
   test('uses the correct values from the config string', function () {
-    const client = new Client('postgres://brian:pass@host1:333/databasename')
+    const client = new Client('gaussdb://brian:pass@host1:333/databasename')
     assert.equal(client.user, 'brian')
     assert.equal(client.password, 'pass')
     assert.equal(client.host, 'host1')
@@ -82,7 +82,7 @@ test('initializing from a config string', function () {
   })
 
   test('uses the correct values from the config string with space in password', function () {
-    const client = new Client('postgres://brian:pass word@host1:333/databasename')
+    const client = new Client('gaussdb://brian:pass word@host1:333/databasename')
     assert.equal(client.user, 'brian')
     assert.equal(client.password, 'pass word')
     assert.equal(client.host, 'host1')
@@ -91,7 +91,7 @@ test('initializing from a config string', function () {
   })
 
   test('when not including all values the defaults are used', function () {
-    const client = new Client('postgres://host1')
+    const client = new Client('gaussdb://host1')
     assert.equal(client.user, process.env['PGUSER'] || process.env.USER)
     assert.equal(client.password, process.env['PGPASSWORD'] || null)
     assert.equal(client.host, 'host1')
@@ -118,7 +118,7 @@ test('initializing from a config string', function () {
     process.env['PGPORT'] = 5464
     process.env['PGDATABASE'] = 'utDB1'
 
-    const client = new Client('postgres://host1')
+    const client = new Client('gaussdb://host1')
     assert.equal(client.user, process.env['PGUSER'])
     assert.equal(client.password, process.env['PGPASSWORD'])
     assert.equal(client.host, 'host1')

--- a/packages/gaussdb/test/unit/client/early-disconnect-tests.js
+++ b/packages/gaussdb/test/unit/client/early-disconnect-tests.js
@@ -11,7 +11,7 @@ const server = net.createServer(function (c) {
 })
 
 server.listen(7777, function () {
-  const client = new pg.Client('postgres://localhost:7777')
+  const client = new pg.Client('gaussdb://localhost:7777')
   client.connect(
     assert.calls(function (err) {
       assert(err)

--- a/packages/gaussdb/test/unit/connection-parameters/creation-tests.js
+++ b/packages/gaussdb/test/unit/connection-parameters/creation-tests.js
@@ -15,7 +15,7 @@ const suite = new helper.Suite()
 suite.test('ConnectionParameters construction', function () {
   assert.ok(new ConnectionParameters(), 'with null config')
   assert.ok(new ConnectionParameters({ user: 'asdf' }), 'with config object')
-  assert.ok(new ConnectionParameters('postgres://localhost/postgres'), 'with connection string')
+  assert.ok(new ConnectionParameters('gaussdb://localhost/postgres'), 'with connection string')
 })
 
 const compare = function (actual, expected, type) {
@@ -61,7 +61,7 @@ suite.test('ConnectionParameters initializing from defaults with connectionStrin
   // Just changing this here doesn't actually work because it's no longer in scope when viewed inside of
   // of ConnectionParameters() so we have to pass in the defaults explicitly to test it
   defaults.connectionString =
-    'postgres://brians-are-the-best:mypassword@foo.bar.net:7777/scoobysnacks?options=-c geqo=off'
+    'gaussdb://brians-are-the-best:mypassword@foo.bar.net:7777/scoobysnacks?options=-c geqo=off'
   const subject = new ConnectionParameters(defaults)
   defaults.connectionString = original_value
   compare(subject, config, 'defaults-connectionString')
@@ -91,17 +91,17 @@ suite.test('ConnectionParameters initializing from config', function () {
 
 suite.test('ConnectionParameters initializing from config and config.connectionString', function () {
   const subject1 = new ConnectionParameters({
-    connectionString: 'postgres://test@host/db',
+    connectionString: 'gaussdb://test@host/db',
   })
   const subject2 = new ConnectionParameters({
-    connectionString: 'postgres://test@host/db?ssl=1',
+    connectionString: 'gaussdb://test@host/db?ssl=1',
   })
   const subject3 = new ConnectionParameters({
-    connectionString: 'postgres://test@host/db',
+    connectionString: 'gaussdb://test@host/db',
     ssl: true,
   })
   const subject4 = new ConnectionParameters({
-    connectionString: 'postgres://test@host/db?ssl=1',
+    connectionString: 'gaussdb://test@host/db?ssl=1',
     ssl: false,
   })
 
@@ -112,12 +112,12 @@ suite.test('ConnectionParameters initializing from config and config.connectionS
 })
 
 suite.test('escape spaces if present', function () {
-  const subject = new ConnectionParameters('postgres://localhost/post gres')
+  const subject = new ConnectionParameters('gaussdb://localhost/post gres')
   assert.equal(subject.database, 'post gres')
 })
 
 suite.test('do not double escape spaces', function () {
-  const subject = new ConnectionParameters('postgres://localhost/post%20gres')
+  const subject = new ConnectionParameters('gaussdb://localhost/post%20gres')
   assert.equal(subject.database, 'post gres')
 })
 
@@ -282,7 +282,7 @@ suite.test('password contains  < and/or >  characters', function () {
     database: 'postgres',
   }
   const connectionString =
-    'postgres://' +
+    'gaussdb://' +
     sourceConfig.user +
     ':' +
     sourceConfig.password +
@@ -299,7 +299,7 @@ suite.test('password contains  < and/or >  characters', function () {
 suite.test('username or password contains weird characters', function () {
   const defaults = require('../../../lib/defaults')
   defaults.ssl = true
-  const strang = 'pg://my f%irst name:is&%awesome!@localhost:9000'
+  const strang = 'gaussdb://my f%irst name:is&%awesome!@localhost:9000'
   const subject = new ConnectionParameters(strang)
   assert.equal(subject.user, 'my f%irst name')
   assert.equal(subject.password, 'is&%awesome!')
@@ -308,7 +308,7 @@ suite.test('username or password contains weird characters', function () {
 })
 
 suite.test('url is properly encoded', function () {
-  const encoded = 'pg://bi%25na%25%25ry%20:s%40f%23@localhost/%20u%2520rl'
+  const encoded = 'gaussdb://bi%25na%25%25ry%20:s%40f%23@localhost/%20u%2520rl'
   const subject = new ConnectionParameters(encoded)
   assert.equal(subject.user, 'bi%na%%ry ')
   assert.equal(subject.password, 's@f#')
@@ -320,7 +320,7 @@ suite.test('ssl is set on client', function () {
   const Client = require('../../../lib/client')
   const defaults = require('../../../lib/defaults')
   defaults.ssl = true
-  const c = new Client('postgres://user:password@host/database')
+  const c = new Client('gaussdb://user:password@host/database')
   assert(c.ssl, 'Client should have ssl enabled via defaults')
 })
 

--- a/packages/gaussdb/test/unit/connection-parameters/environment-variable-tests.js
+++ b/packages/gaussdb/test/unit/connection-parameters/environment-variable-tests.js
@@ -59,7 +59,7 @@ suite.test('ConnectionParameters initialized from mix', function () {
 
 suite.test('connection string parsing', function () {
   clearEnv()
-  const string = 'postgres://brian:pw@boom:381/lala'
+  const string = 'gaussdb://brian:pw@boom:381/lala'
   const subject = new ConnectionParameters(string)
   assert.equal(subject.host, 'boom', 'string host')
   assert.equal(subject.user, 'brian', 'string user')
@@ -72,27 +72,27 @@ suite.test('connection string parsing - ssl', function () {
   // clear process.env
   clearEnv()
 
-  let string = 'postgres://brian:pw@boom:381/lala?ssl=true'
+  let string = 'gaussdb://brian:pw@boom:381/lala?ssl=true'
   let subject = new ConnectionParameters(string)
   assert.equal(subject.ssl, true, 'ssl')
 
-  string = 'postgres://brian:pw@boom:381/lala?ssl=1'
+  string = 'gaussdb://brian:pw@boom:381/lala?ssl=1'
   subject = new ConnectionParameters(string)
   assert.equal(subject.ssl, true, 'ssl')
 
-  string = 'postgres://brian:pw@boom:381/lala?other&ssl=true'
+  string = 'gaussdb://brian:pw@boom:381/lala?other&ssl=true'
   subject = new ConnectionParameters(string)
   assert.equal(subject.ssl, true, 'ssl')
 
-  string = 'postgres://brian:pw@boom:381/lala?ssl=0'
+  string = 'gaussdb://brian:pw@boom:381/lala?ssl=0'
   subject = new ConnectionParameters(string)
   assert.equal(!!subject.ssl, false, 'ssl')
 
-  string = 'postgres://brian:pw@boom:381/lala'
+  string = 'gaussdb://brian:pw@boom:381/lala'
   subject = new ConnectionParameters(string)
   assert.equal(!!subject.ssl, false, 'ssl')
 
-  string = 'postgres://brian:pw@boom:381/lala?ssl=no-verify'
+  string = 'gaussdb://brian:pw@boom:381/lala?ssl=no-verify'
   subject = new ConnectionParameters(string)
   assert.deepStrictEqual(subject.ssl, { rejectUnauthorized: false }, 'ssl')
 })


### PR DESCRIPTION
- 更新了连接字符串解析逻辑以识别 `gaussdb://`
- 修改了测试用例
- 修改了 README
- 不再追踪 `.nyc_output` 目录